### PR TITLE
Add ListId property to SPFx webpart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+lib/
+dist/
+release/
+temp/
+*.scss.ts

--- a/README.md
+++ b/README.md
@@ -46,9 +46,16 @@ Short summary on functionality and used technologies.
 - Ensure that you are at the solution folder
 - in the command-line run:
   - **npm install**
+  - **gulp build** (optional for a production bundle)
   - **gulp serve**
 
+Ensure the `initialPage` setting in `config/serve.json` uses your tenant domain before running `gulp serve`.
+
 > Include any additional steps as needed.
+
+## Web part properties
+
+This sample exposes a `ListId` string property that you can configure in the property pane and reuse in your custom code.
 
 ## Features
 

--- a/src/webparts/testCodex/TestCodexWebPart.manifest.json
+++ b/src/webparts/testCodex/TestCodexWebPart.manifest.json
@@ -22,7 +22,8 @@
     "description": { "default": "Test_Codex description" },
     "officeFabricIconFontName": "Page",
     "properties": {
-      "description": "Test_Codex"
+      "description": "Test_Codex",
+      "listId": ""
     }
   }]
 }

--- a/src/webparts/testCodex/TestCodexWebPart.ts
+++ b/src/webparts/testCodex/TestCodexWebPart.ts
@@ -14,6 +14,7 @@ import { ITestCodexProps } from './components/ITestCodexProps';
 
 export interface ITestCodexWebPartProps {
   description: string;
+  listId: string;
 }
 
 export default class TestCodexWebPart extends BaseClientSideWebPart<ITestCodexWebPartProps> {
@@ -26,6 +27,7 @@ export default class TestCodexWebPart extends BaseClientSideWebPart<ITestCodexWe
       TestCodex,
       {
         description: this.properties.description,
+        listId: this.properties.listId,
         isDarkTheme: this._isDarkTheme,
         environmentMessage: this._environmentMessage,
         hasTeamsContext: !!this.context.sdks.microsoftTeams,
@@ -110,6 +112,9 @@ export default class TestCodexWebPart extends BaseClientSideWebPart<ITestCodexWe
               groupFields: [
                 PropertyPaneTextField('description', {
                   label: strings.DescriptionFieldLabel
+                }),
+                PropertyPaneTextField('listId', {
+                  label: strings.ListIdFieldLabel
                 })
               ]
             }

--- a/src/webparts/testCodex/components/ITestCodexProps.ts
+++ b/src/webparts/testCodex/components/ITestCodexProps.ts
@@ -4,4 +4,5 @@ export interface ITestCodexProps {
   environmentMessage: string;
   hasTeamsContext: boolean;
   userDisplayName: string;
+  listId: string;
 }

--- a/src/webparts/testCodex/components/TestCodex.tsx
+++ b/src/webparts/testCodex/components/TestCodex.tsx
@@ -10,7 +10,8 @@ export default class TestCodex extends React.Component<ITestCodexProps> {
       isDarkTheme,
       environmentMessage,
       hasTeamsContext,
-      userDisplayName
+      userDisplayName,
+      listId
     } = this.props;
 
     return (
@@ -20,6 +21,7 @@ export default class TestCodex extends React.Component<ITestCodexProps> {
           <h2>Well done, {escape(userDisplayName)}!</h2>
           <div>{environmentMessage}</div>
           <div>Web part property value: <strong>{escape(description)}</strong></div>
+          <div>List Id: <strong>{escape(listId)}</strong></div>
         </div>
         <div>
           <h3>Welcome to SharePoint Framework!</h3>

--- a/src/webparts/testCodex/loc/en-us.js
+++ b/src/webparts/testCodex/loc/en-us.js
@@ -3,6 +3,7 @@ define([], function() {
     "PropertyPaneDescription": "Description",
     "BasicGroupName": "Group Name",
     "DescriptionFieldLabel": "Description Field",
+    "ListIdFieldLabel": "List Id",
     "AppLocalEnvironmentSharePoint": "The app is running on your local environment as SharePoint web part",
     "AppLocalEnvironmentTeams": "The app is running on your local environment as Microsoft Teams app",
     "AppLocalEnvironmentOffice": "The app is running on your local environment in office.com",
@@ -12,5 +13,4 @@ define([], function() {
     "AppOfficeEnvironment": "The app is running in office.com",
     "AppOutlookEnvironment": "The app is running in Outlook",
     "UnknownEnvironment": "The app is running in an unknown environment"
-  }
-});
+  }});

--- a/src/webparts/testCodex/loc/mystrings.d.ts
+++ b/src/webparts/testCodex/loc/mystrings.d.ts
@@ -2,6 +2,7 @@ declare interface ITestCodexWebPartStrings {
   PropertyPaneDescription: string;
   BasicGroupName: string;
   DescriptionFieldLabel: string;
+  ListIdFieldLabel: string;
   AppLocalEnvironmentSharePoint: string;
   AppLocalEnvironmentTeams: string;
   AppLocalEnvironmentOffice: string;


### PR DESCRIPTION
## Summary
- introduce `ListId` string property to TestCodex webpart
- pass `listId` to React component
- expose field in property pane and manifest
- display property in component
- document build & serve steps and mention ListId property
- add standard `.gitignore`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e4060bc74832fa878b095927ee410